### PR TITLE
Update to support actionSupport with event=onchange

### DIFF
--- a/src/components/Typeahead.component
+++ b/src/components/Typeahead.component
@@ -133,8 +133,8 @@
 					j$(ctrl).attr('data-id', id);
 
 					// if destinations are defined, set them too
-					j$('[id$={!destinationForSelectedId}]').val( id );
-					j$('[id$={!destinationForSelectedValue}]').val( value );
+					j$('[id$={!destinationForSelectedId}]').val( id ).change();
+					j$('[id$={!destinationForSelectedValue}]').val( value ).change();
 				},
 
 			fieldList: 


### PR DESCRIPTION
You can now support the onchange event. For reference see: http://stackoverflow.com/questions/2026704/what-event-can-be-captured-when-an-html-hidden-input-value-is-set-changed
