### PR TITLE
VF component IDs with colons

### DIFF
--- a/src/components/Typeahead.component
+++ b/src/components/Typeahead.component
@@ -133,8 +133,8 @@
 					j$(ctrl).attr('data-id', id);
 
 					// if destinations are defined, set them too
-					j$('[id$={!destinationForSelectedId}]').val( id );
-					j$('[id$={!destinationForSelectedValue}]').val( value );
+					j$('[id$={!destinationForSelectedId}]'.replace(/:/g,'\\:')).val( id );
+					j$('[id$={!destinationForSelectedValue}]'.replace(/:/g,'\\:'))).val( value );
 				},
 
 			fieldList: 

--- a/src/components/Typeahead.component
+++ b/src/components/Typeahead.component
@@ -134,7 +134,7 @@
 
 					// if destinations are defined, set them too
 					j$('[id$={!destinationForSelectedId}]'.replace(/:/g,'\\:')).val( id );
-					j$('[id$={!destinationForSelectedValue}]'.replace(/:/g,'\\:'))).val( value );
+					j$('[id$={!destinationForSelectedValue}]'.replace(/:/g,'\\:')).val( value );
 				},
 
 			fieldList: 


### PR DESCRIPTION
Some VF components (e.g. apex:inputHidden) cannot be assigned dynamic
IDs. We have to reference them like:

destinationForSelectedId="{!$Component.ProductId}"

As a result, the component ID contains multiple colons, e.g.:

j$('[id$=thePage:theForm:thePageBlock:lineItemsTable:0:ProductId]')

I’ve added code to escape these colons, which confuse jQuery.
