### PR TITLE
Updated TypeAhead component

### DIFF
--- a/src/components/Typeahead.component
+++ b/src/components/Typeahead.component
@@ -131,10 +131,15 @@
 
 					// put the id on the input tag
 					j$(ctrl).attr('data-id', id);
+					 var selectedId = '{!destinationForSelectedId}';
+				         var selectedValue = '{!destinationForSelectedValue}';
 
 					// if destinations are defined, set them too
-					j$('[id$={!destinationForSelectedId}]').val( id );
-					j$('[id$={!destinationForSelectedValue}]').val( value );
+					   if(selectedId != '')
+					   	j$('[id$='+selectedId+']').val( id );
+
+					    if(selectedValue != '')
+					         j$('[id$='+selectedValue+']').val( value );
 				},
 
 			fieldList: 


### PR DESCRIPTION
Added logic to not attempt to add destinationForSelectedId and destinationForSelectedValue when these attributes are not assigned, since these attributes are not required they cause an error when they don't have a value.